### PR TITLE
update gemspec for jekyll 4 + documentation addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,27 @@ In any page or post, use #hashtags as you would normally, e.g.
 > Hey <a href="/tags/AmazonGo" target="_blank" class="hashtag">#AmazonGo</a>, what do you think?
 
 
+## Configuration
+
+Have your own social network? No problem. We allow you to configure the base URL of all the hashtags.
+
+To change it, add the following to your Jekyll configuration:
+
+```yml
+jekyll-hashtags:
+  base_url: https://hengwei.me
+```
+
+An example of Twitter hashtags using jekyll-hashtags:
+
+```yml
+plugins:
+  - jekyll-hashtags
+
+jekyll-hashtags:
+  base_url: https://twitter.com/hashtag/
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/jekyll-hashtags.gemspec
+++ b/jekyll-hashtags.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "jekyll", "> 3.0", "< 5.0"
   spec.add_dependency "html-pipeline-hashtag", "~> 0.1.1"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/jekyll-hashtags.gemspec
+++ b/jekyll-hashtags.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_dependency "jekyll", "~> 3.0"
+  spec.add_dependency "jekyll", "> 3.0", "< 5.0"
   spec.add_dependency "html-pipeline-hashtag", "~> 0.1.1"
 
   spec.add_development_dependency "bundler", "~> 1.16"


### PR DESCRIPTION
i couldn't run jekyll-hashtags on jekyll 4 due to gemspec limitations, so i updated it and ran your rspec tests, which completed fine. also added (and tweaked) the configuration section from your rubydoc.info page.

edit: i didn't update the version number.
