### PR TITLE
Automatically add hashtags to page/post tag metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,26 @@ In any page or post, use #hashtags as you would normally, e.g.
 > Hey <a href="/tags/AmazonGo" target="_blank" class="hashtag">#AmazonGo</a>, what do you think?
 
 
+## Configuration
+
+  Have your own social network? No problem. We allow you to configure the base URL of all the hashtags.
+
+  To change it, add the following to your Jekyll configuration:
+
+  ```yml
+ jekyll-hashtags:
+   base_url: https://hengwei.me
+ ```
+
+  An example of Twitter hashtags using jekyll-hashtags:
+
+  ```yml
+ plugins:
+   - jekyll-hashtags
+
+ jekyll-hashtags:
+   base_url: https://twitter.com/hashtag/
+ ```
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/jekyll-hashtags.gemspec
+++ b/jekyll-hashtags.gemspec
@@ -34,10 +34,10 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_dependency "jekyll", "~> 3.0"
+  spec.add_dependency "jekyll", "> 3.0", "<5.0"
   spec.add_dependency "html-pipeline-hashtag", "~> 0.1.1"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/jekyll-hashtags.rb
+++ b/lib/jekyll-hashtags.rb
@@ -32,6 +32,15 @@ module Jekyll
         end
       end
 
+      # Public: Find all the tags in the doc and add it to doc.data['tags']
+      def hashtag_init(doc)
+        tags = doc.data['tags']
+        found_tags = doc.content.scan(/#([\p{L}\w\-]+)/)
+        for tag in found_tags
+          tags.append(tag) unless tags.include?(tag)
+        end
+      end
+
         # Public: Create or fetch the filter for the given {{src}} base URL.
         #
         # :doc
@@ -143,4 +152,8 @@ end
 
 Jekyll::Hooks.register %i[pages documents], :post_render do |doc|
   Jekyll::Hashtags.hashtag_it(doc) if Jekyll::Hashtags.tagable?(doc)
+end
+
+Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc|
+  Jekyll::Hashtags.hashtag_init(doc) 
 end

--- a/lib/jekyll-hashtags.rb
+++ b/lib/jekyll-hashtags.rb
@@ -34,6 +34,9 @@ module Jekyll
 
       # Public: Find all the tags in the doc and add it to doc.data['tags']
       def hashtag_pre_render(doc)
+        if doc.content == nil
+          return
+        end
         found_hashtags = doc.content.scan(/\s#([\p{L}\w\-]+)/)
         if found_hashtags.empty?
           return

--- a/lib/jekyll-hashtags.rb
+++ b/lib/jekyll-hashtags.rb
@@ -33,12 +33,24 @@ module Jekyll
       end
 
       # Public: Find all the tags in the doc and add it to doc.data['tags']
-      def hashtag_init(doc)
-        tags = doc.data['tags']
-        found_tags = doc.content.scan(/#([\p{L}\w\-]+)/)
-        for tag in found_tags
-          tags.append(tag) unless tags.include?(tag)
+      def hashtag_pre_render(doc)
+        found_hashtags = doc.content.scan(/#([\p{L}\w\-]+)/)
+        if found_hashtags == nil
+          return
         end
+
+        tags = doc.data['tags']
+        # puts tags.class
+        if tags == nil
+          tags = []
+        end
+
+        for tag in found_hashtags
+          # puts '---"#{tag}"---'
+          # puts tag[0].class
+          tags.append(tag[0]) unless tags.include?(tag[0])
+        end
+        doc.data['tags'] = tags
       end
 
         # Public: Create or fetch the filter for the given {{src}} base URL.
@@ -155,5 +167,5 @@ Jekyll::Hooks.register %i[pages documents], :post_render do |doc|
 end
 
 Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc|
-  Jekyll::Hashtags.hashtag_init(doc) 
+  Jekyll::Hashtags.hashtag_pre_render(doc) 
 end

--- a/lib/jekyll-hashtags.rb
+++ b/lib/jekyll-hashtags.rb
@@ -34,8 +34,8 @@ module Jekyll
 
       # Public: Find all the tags in the doc and add it to doc.data['tags']
       def hashtag_pre_render(doc)
-        found_hashtags = doc.content.scan(/#([\p{L}\w\-]+)/)
-        if found_hashtags == nil
+        found_hashtags = doc.content.scan(/\s#([\p{L}\w\-]+)/)
+        if found_hashtags.empty?
           return
         end
 

--- a/lib/jekyll-hashtags.rb
+++ b/lib/jekyll-hashtags.rb
@@ -37,23 +37,14 @@ module Jekyll
         if doc.content == nil
           return
         end
-        found_hashtags = doc.content.scan(/\s#([\p{L}\w\-]+)/)
+        found_hashtags = doc.content.scan(/\s#([\p{L}\w\-]+)/).map { | tag | tag[0] }
         if found_hashtags.empty?
           return
         end
 
-        tags = doc.data['tags']
-        # puts tags.class
-        if tags == nil
-          tags = []
-        end
-
-        for tag in found_hashtags
-          # puts '---"#{tag}"---'
-          # puts tag[0].class
-          tags.append(tag[0]) unless tags.include?(tag[0])
-        end
-        doc.data['tags'] = tags
+        tags = doc.data['tags'] || []
+        tags.concat(found_hashtags.uniq)
+        doc.data['tags'] = tags.uniq
       end
 
         # Public: Create or fetch the filter for the given {{src}} base URL.

--- a/lib/jekyll-hashtags/version.rb
+++ b/lib/jekyll-hashtags/version.rb
@@ -1,3 +1,3 @@
 module JekyllHashtags
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/spec/blog/Gemfile
+++ b/spec/blog/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 group :jekyll_plugins do
-  gem 'jekyll-hashtags'
+  # gem 'jekyll-hashtags'
 end
 
-#gem 'jekyll-hashtags', :path => 'local/path/for/development'
+gem 'jekyll-hashtags', :path => '../../'
+gem 'webrick'

--- a/spec/blog/index.md
+++ b/spec/blog/index.md
@@ -1,6 +1,17 @@
 ---
 layout: default
 title: I'm a page
+regenerate: true
+tags:
+  - one
+  - two
+  - three
 ---
 
-test #AmazonGo test
+test #AmazonGo test #again #once-more
+
+<ul>
+  {% for tag in page.tags %}
+    <li>{{ tag }}</li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
This Pull Request automatically adds the hashtag to the tag metadata for each page or post. This makes it so you don't have to do this manually.

It also updates the compatible Jekyll version.